### PR TITLE
Supports DataStreams

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # firetap
 
-firetap is an AWS Lambda extension to transport logs to Kinesis Firehose.
+firetap is an AWS Lambda extension to transport logs to Kinesis Data Firehose or Kinesis Data Streams.
 
 This is an alpha version and not recommended for production use.
 
@@ -30,6 +30,13 @@ $ aws lambda publish-layer-version \
 		--zip-file fileb://layer.zip \
 		--compatible-runtimes provided.al2023 provided.al2
 ```
+
+#### Configurations
+
+You can configure `firetap` by setting environment variables.
+
+- `FIRETAP_STREAM_NAME`: The name of the Kinesis Data Firehose or Kinesis Data Streams stream.
+- `FIRETAP_USE_DATA_STREAM`: Set `true` if you want to use Kinesis Data Streams. Default is `false` (use Firehose).
 
 ### Bootstrap Wrapper
 

--- a/firetap.go
+++ b/firetap.go
@@ -79,6 +79,8 @@ func Wrapper(ctx context.Context, handler string) error {
 }
 
 func Run(ctx context.Context, opt *Option) error {
+	logger.Info("running firetap", "option", opt)
+
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
@@ -94,7 +96,7 @@ func Run(ctx context.Context, opt *Option) error {
 		return err
 	}
 
-	sn, err := startSender(ctx, opt.StreamName)
+	sn, err := startSender(ctx, opt.StreamName, opt.DataStream)
 	if err != nil {
 		logger.Error("failed to start sender", "error", err)
 		return err

--- a/go.mod
+++ b/go.mod
@@ -6,11 +6,13 @@ require (
 	github.com/Songmu/wrapcommander v0.1.0
 	github.com/aws/aws-sdk-go-v2/config v1.27.11
 	github.com/aws/aws-sdk-go-v2/service/firehose v1.28.6
+	github.com/aws/aws-sdk-go-v2/service/kinesis v1.27.4
 	github.com/shogo82148/go-retry v1.2.0
 )
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.26.1 // indirect
+	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.6.2 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.11 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.1 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.5 // indirect
@@ -22,4 +24,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.23.4 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.28.6 // indirect
 	github.com/aws/smithy-go v1.20.2 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/jmespath/go-jmespath v0.4.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/Songmu/wrapcommander v0.1.0 h1:y8/yk9/PHT983weH+ehZIOJ7JtwAlI1AkfUpUN
 github.com/Songmu/wrapcommander v0.1.0/go.mod h1:EC2y4OnN8PkdMnaCwcSzItewq+f0yqUvS30kcS4vmn0=
 github.com/aws/aws-sdk-go-v2 v1.26.1 h1:5554eUqIYVWpU0YmeeYZ0wU64H2VLBs8TlhRB2L+EkA=
 github.com/aws/aws-sdk-go-v2 v1.26.1/go.mod h1:ffIFB97e2yNsv4aTSGkqtHnppsIJzw7G7BReUZ3jCXM=
+github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.6.2 h1:x6xsQXGSmW6frevwDA+vi/wqhp1ct18mVXYN08/93to=
+github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.6.2/go.mod h1:lPprDr1e6cJdyYeGXnRaJoP4Md+cDBvi2eOj00BlGmg=
 github.com/aws/aws-sdk-go-v2/config v1.27.11 h1:f47rANd2LQEYHda2ddSCKYId18/8BhSRM4BULGmfgNA=
 github.com/aws/aws-sdk-go-v2/config v1.27.11/go.mod h1:SMsV78RIOYdve1vf36z8LmnszlRWkwMQtomCAI0/mIE=
 github.com/aws/aws-sdk-go-v2/credentials v1.17.11 h1:YuIB1dJNf1Re822rriUOTxopaHHvIq0l/pX3fwO+Tzs=
@@ -20,6 +22,8 @@ github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.11.2 h1:Ji0DY1x
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.11.2/go.mod h1:5CsjAbs3NlGQyZNFACh+zztPDI7fU6eW9QsxjfnuBKg=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.11.7 h1:ogRAwT1/gxJBcSWDMZlgyFUM962F51A5CRhDLbxLdmo=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.11.7/go.mod h1:YCsIZhXfRPLFFCl5xxY+1T9RKzOKjCut+28JSX2DnAk=
+github.com/aws/aws-sdk-go-v2/service/kinesis v1.27.4 h1:Oe8awBiS/iitcsRJB5+DHa3iCxoA0KwJJf0JNrYMINY=
+github.com/aws/aws-sdk-go-v2/service/kinesis v1.27.4/go.mod h1:RCZCSFbieSgNG1RKegO26opXV4EXyef/vNBVJsUyHuw=
 github.com/aws/aws-sdk-go-v2/service/sso v1.20.5 h1:vN8hEbpRnL7+Hopy9dzmRle1xmDc7o8tmY0klsr175w=
 github.com/aws/aws-sdk-go-v2/service/sso v1.20.5/go.mod h1:qGzynb/msuZIE8I75DVRCUXw3o3ZyBmUvMwQ2t/BrGM=
 github.com/aws/aws-sdk-go-v2/service/ssooidc v1.23.4 h1:Jux+gDDyi1Lruk+KHF91tK2KCuY61kzoCpvtvJJBtOE=
@@ -28,5 +32,18 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.28.6 h1:cwIxeBttqPN3qkaAjcEcsh8NYr8n
 github.com/aws/aws-sdk-go-v2/service/sts v1.28.6/go.mod h1:FZf1/nKNEkHdGGJP/cI2MoIMquumuRK6ol3QQJNDxmw=
 github.com/aws/smithy-go v1.20.2 h1:tbp628ireGtzcHDDmLT/6ADHidqnwgF57XOXZe6tp4Q=
 github.com/aws/smithy-go v1.20.2/go.mod h1:krry+ya/rV9RDcV/Q16kpu6ypI4K2czasz0NC3qS14E=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
+github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
+github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=
+github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/shogo82148/go-retry v1.2.0 h1:A/LFdbZKJ+tsT1gF4OrzM4P10FGK7VUExpb07/U03aE=
 github.com/shogo82148/go-retry v1.2.0/go.mod h1:wttfgfwCMQvNqv4kOpqIvDDJeSmwU+AEIpUyG+5Ca6M=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
+gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/option.go
+++ b/option.go
@@ -3,15 +3,19 @@ package firetap
 import (
 	"fmt"
 	"os"
+	"strconv"
 )
 
 type Option struct {
-	StreamName string // StreamName is the name of the Kinesis Firehose stream.
+	StreamName string // StreamName is the name of the Kinesis Firehose/DataStream stream name.
+	DataStream bool   // DataStream is the flag to use DataStream instead of Firehose.
 }
 
 func NewOption() (*Option, error) {
+	ds, _ := strconv.ParseBool(os.Getenv("FIRETAP_DATA_STREAM"))
 	opt := &Option{
 		StreamName: os.Getenv("FIRETAP_STREAM_NAME"),
+		DataStream: ds,
 	}
 	if opt.StreamName == "" {
 		return nil, fmt.Errorf("FIRETAP_STREAM_NAME is required")

--- a/sender.go
+++ b/sender.go
@@ -6,36 +6,43 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/firehose"
-	"github.com/aws/aws-sdk-go-v2/service/firehose/types"
+	firehoseTypes "github.com/aws/aws-sdk-go-v2/service/firehose/types"
+	"github.com/aws/aws-sdk-go-v2/service/kinesis"
+	kinesisTypes "github.com/aws/aws-sdk-go-v2/service/kinesis/types"
 	"github.com/shogo82148/go-retry"
 )
 
-const maxFirehoseBatchSize = 500
+const maxBatchSize = 500
 
-var firehoseRetryPolicy = retry.Policy{
+var retryPolicy = retry.Policy{
 	MinDelay: 100 * time.Millisecond,
 	MaxDelay: 2 * time.Second,
 	MaxCount: 10,
 }
 
 type LogSender struct {
-	stream   string
-	buf      [][]byte
-	firehose *firehose.Client
+	streamName string
+	buf        [][]byte
+	bufSize    int
+	firehose   *firehose.Client
+	kinesis    *kinesis.Client
 }
 
-func startSender(ctx context.Context, stream string) (*LogSender, error) {
+func startSender(ctx context.Context, streamName string, dataStream bool) (*LogSender, error) {
 	awsCfg, err := config.LoadDefaultConfig(ctx)
 	if err != nil {
 		return nil, err
 	}
-	firehoseClient := firehose.NewFromConfig(awsCfg)
-
-	return &LogSender{
-		stream:   stream,
-		firehose: firehoseClient,
-		buf:      make([][]byte, 0, maxFirehoseBatchSize),
-	}, nil
+	s := &LogSender{
+		streamName: streamName,
+		buf:        make([][]byte, 0, maxBatchSize),
+	}
+	if dataStream {
+		s.kinesis = kinesis.NewFromConfig(awsCfg)
+	} else {
+		s.firehose = firehose.NewFromConfig(awsCfg)
+	}
+	return s, nil
 }
 
 func (s *LogSender) Run(ctx context.Context, rch <-chan []byte) error {
@@ -49,9 +56,10 @@ func (s *LogSender) Run(ctx context.Context, rch <-chan []byte) error {
 		case <-tk.C:
 			s.flush(ctx)
 		case msg := <-rch:
-			if len(s.buf) == maxFirehoseBatchSize {
+			if len(s.buf) == maxBatchSize || s.bufSize+len(msg) > 1024*512 {
 				s.flush(ctx)
 			}
+			s.bufSize += len(msg)
 			s.buf = append(s.buf, msg)
 		}
 	}
@@ -61,15 +69,23 @@ func (s *LogSender) flush(ctx context.Context) {
 	if len(s.buf) == 0 {
 		return
 	}
-	recs := make([]types.Record, 0, len(s.buf))
+	if s.kinesis != nil {
+		s.flushToKinesis(ctx)
+	} else {
+		s.flushToFirehose(ctx)
+	}
+}
+
+func (s *LogSender) flushToFirehose(ctx context.Context) {
+	recs := make([]firehoseTypes.Record, 0, len(s.buf))
 	for _, r := range s.buf {
-		recs = append(recs, types.Record{Data: r})
+		recs = append(recs, firehoseTypes.Record{Data: r})
 	}
 	logger.Debug("sending to firehose", "records", len(recs))
 
-	err := firehoseRetryPolicy.Do(ctx, func() error {
+	err := retryPolicy.Do(ctx, func() error {
 		_, err := s.firehose.PutRecordBatch(ctx, &firehose.PutRecordBatchInput{
-			DeliveryStreamName: &s.stream,
+			DeliveryStreamName: &s.streamName,
 			Records:            recs,
 		})
 		return err
@@ -82,5 +98,36 @@ func (s *LogSender) flush(ctx context.Context) {
 	} else {
 		logger.Info("sent to firehose", "records", len(recs))
 	}
-	s.buf = s.buf[:0] // clear buffer
+	s.resetBuffer()
+}
+
+func (s *LogSender) flushToKinesis(ctx context.Context) {
+	recs := make([]kinesisTypes.PutRecordsRequestEntry, 0, len(s.buf))
+	for _, r := range s.buf {
+		recs = append(recs, kinesisTypes.PutRecordsRequestEntry{Data: r})
+	}
+
+	logger.Debug("sending to kinesis", "records", len(recs))
+
+	err := retryPolicy.Do(ctx, func() error {
+		_, err := s.kinesis.PutRecords(ctx, &kinesis.PutRecordsInput{
+			Records:    recs,
+			StreamName: &s.streamName,
+		})
+		return err
+	})
+	if err != nil {
+		logger.Warn("failed to send to kinesis", "error", err)
+		for _, m := range s.buf {
+			logger.Warn("overflow", "message", string(m))
+		}
+	} else {
+		logger.Info("sent to kinesis", "records", len(recs))
+	}
+	s.resetBuffer()
+}
+
+func (s *LogSender) resetBuffer() {
+	s.buf = s.buf[:0]
+	s.bufSize = 0
 }


### PR DESCRIPTION
`FIRETAP_USE_DATA_STREAM=t` enables to send logs to Kinesis Data Streams instead of Firehose.